### PR TITLE
order information type changed

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,8 @@
 export type OrderInformation = {
-  orderNumber: number;
+  _id: string;
   menu: string;
-  topping: string;
+  arranges: string[];
+  orderState: 'waiting' | 'available' | 'finished';
+  updated_at: Date;
+  created_at: Date;
 };


### PR DESCRIPTION
## チケットへのリンク

-https://www.notion.so/OrderInformation-type-mongoDB-8c31f36ab7e54960bc507f0f5ecb7a9f?pvs=4

## やったこと

- orderInformationのtypeをmongoDBに合わせた。

## やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）

## 動作確認

- なし

## 動作確認用 URL

- なし

## スクリーンショット

- なし

## その他

