### PR TITLE
feat:カートの状態管理をグローバル化

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.11.0",
         "@reduxjs/toolkit": "^1.9.7",
         "@tanstack/react-query": "^5.0.0",
+        "@types/react-redux": "^7.1.28",
         "@types/react-router-dom": "^5.3.3",
         "axios": "^1.5.1",
         "embla-carousel-react": "^8.0.0-rc14",
@@ -24,6 +25,7 @@
         "react-query": "^3.39.3",
         "react-redux": "^8.1.3",
         "react-router-dom": "^6.16.0",
+        "redux-thunk": "^2.4.2",
         "sort-by": "^0.0.2",
         "uuid": "^9.0.1"
       },
@@ -2078,6 +2080,17 @@
       "devOptional": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.28",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.28.tgz",
+      "integrity": "sha512-EQr7cChVzVUuqbA+J8ArWK1H0hLAHKOs21SIMrskKZ3nHNeE+LFYA+IsoZGhVOT8Ktjn3M20v4rnZKN3fLbypw==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/react-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@emotion/styled": "^11.11.0",
     "@reduxjs/toolkit": "^1.9.7",
     "@tanstack/react-query": "^5.0.0",
+    "@types/react-redux": "^7.1.28",
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.5.1",
     "embla-carousel-react": "^8.0.0-rc14",
@@ -26,6 +27,7 @@
     "react-query": "^3.39.3",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.16.0",
+    "redux-thunk": "^2.4.2",
     "sort-by": "^0.0.2",
     "uuid": "^9.0.1"
   },

--- a/frontend/src/components/features/delivery/presenter/DeliveryUI.tsx
+++ b/frontend/src/components/features/delivery/presenter/DeliveryUI.tsx
@@ -31,6 +31,7 @@ const DeliveryUI = () => {
       },
       menus: [
         {
+          id: v4(),
           name: 'ソース',
           price: 250,
           arranges: {
@@ -41,6 +42,7 @@ const DeliveryUI = () => {
           },
         },
         {
+          id: v4(),
           name: 'めんたい',
           price: 300,
           arranges: {
@@ -203,6 +205,7 @@ const DeliveryUI = () => {
                 },
                 menus: [
                   {
+                    id: v4(),
                     name: 'ソース',
                     price: 250,
                     arranges: {
@@ -213,6 +216,7 @@ const DeliveryUI = () => {
                     },
                   },
                   {
+                    id: v4(),
                     name: 'めんたい',
                     price: 300,
                     arranges: {

--- a/frontend/src/components/features/reception/container/ReceptionContainer.tsx
+++ b/frontend/src/components/features/reception/container/ReceptionContainer.tsx
@@ -1,7 +1,14 @@
+import { useSelector } from 'react-redux';
 import ReceptionUI from '../presenter/ReceptionUI';
+import { RootState } from '../../../../state/common/rootState.type';
 
 const ReceptionContainer = () => {
-  return <ReceptionUI />;
+  const cart = useSelector((state: RootState) => state.cart);
+
+  const args = {
+    cart: cart,
+  };
+  return <ReceptionUI {...args} />;
 };
 
 export default ReceptionContainer;

--- a/frontend/src/components/features/reception/container/ReceptionContainer.tsx
+++ b/frontend/src/components/features/reception/container/ReceptionContainer.tsx
@@ -1,12 +1,49 @@
 import { useSelector } from 'react-redux';
 import ReceptionUI from '../presenter/ReceptionUI';
 import { RootState } from '../../../../state/common/rootState.type';
+import { useDispatch } from 'react-redux';
+import { MenuInformation } from '../../../../types';
+import {
+  ArrangeState,
+  addMenu,
+  removeMenu,
+  updateCheckBox,
+} from '../../../../state/cart/cartSlice';
 
 const ReceptionContainer = () => {
   const cart = useSelector((state: RootState) => state.cart);
 
+  const dispatch = useDispatch();
+
+  const handleAddToCart = ({ name, price, arranges, id }: MenuInformation) => {
+    const newMenu = {
+      id,
+      name,
+      price,
+      arranges,
+    };
+    dispatch(addMenu(newMenu));
+  };
+
+  const handleDeleteFromCart = (id: string) => {
+    dispatch(removeMenu(id));
+  };
+
+  const handleUpdateOrderCheck = ({ id, arrange, checked }: ArrangeState) => {
+    dispatch(
+      updateCheckBox({
+        id,
+        arrange,
+        checked,
+      }),
+    );
+  };
+
   const args = {
     cart: cart,
+    handleAddToCart: handleAddToCart,
+    handleDeleteFromCart: handleDeleteFromCart,
+    handleUpdateOrderCheck: handleUpdateOrderCheck,
   };
   return <ReceptionUI {...args} />;
 };

--- a/frontend/src/components/features/reception/container/ReceptionContainer.tsx
+++ b/frontend/src/components/features/reception/container/ReceptionContainer.tsx
@@ -7,6 +7,7 @@ import {
   ArrangeState,
   addMenu,
   removeMenu,
+  removeMenuByIndex,
   updateCheckBox,
 } from '../../../../state/cart/cartSlice';
 
@@ -38,12 +39,18 @@ const ReceptionContainer = () => {
       }),
     );
   };
+  //ここで２回消しているのは、セット商品の場合、配列の中に二つ並んで入っているため
+  const handleDeleteSetMenu = (index: number) => {
+    dispatch(removeMenuByIndex(index));
+    dispatch(removeMenuByIndex(index));
+  };
 
   const args = {
     cart: cart,
     handleAddToCart: handleAddToCart,
     handleDeleteFromCart: handleDeleteFromCart,
     handleUpdateOrderCheck: handleUpdateOrderCheck,
+    handleDeleteSetMenu: handleDeleteSetMenu,
   };
   return <ReceptionUI {...args} />;
 };

--- a/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
+++ b/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
@@ -36,135 +36,7 @@ const ReceptionUI: FC<ReceptionUIProps> = ({
   return (
     <Box maxHeight="100vh">
       <HStack>
-        <VStack>
-          <OrderHistoryDrawer />
-          <HStack>
-            <Button
-              fontSize={{ base: '50px', sm: '24px' }}
-              h={{ base: '100px', sm: '200px' }}
-              w={{ base: '100px', sm: '200px' }}
-              p={4}
-              m={4}
-              onClick={() =>
-                handleAddToCart({
-                  id: v4(),
-                  name: 'ソース',
-                  price: 250,
-                  arranges: {
-                    ソース: true,
-                    マヨ: true,
-                    アオサ: true,
-                    カツオ: true,
-                  },
-                })
-              }
-            >
-              ソース
-            </Button>
-            <Button
-              fontSize={{ base: '50px', sm: '24px' }}
-              h={{ base: '100px', sm: '200px' }}
-              w={{ base: '100px', sm: '200px' }}
-              p={4}
-              m={4}
-              onClick={() =>
-                handleAddToCart({
-                  id: v4(),
-                  name: 'ソース前売り',
-                  price: 0,
-                  arranges: {
-                    ソース: true,
-                    マヨ: true,
-                    アオサ: true,
-                    カツオ: true,
-                  },
-                })
-              }
-            >
-              ソース前売り券
-            </Button>
-          </HStack>
-          <HStack>
-            <Button
-              fontSize={{ base: '50px', sm: '24px' }}
-              h={{ base: '100px', sm: '200px' }}
-              w={{ base: '100px', sm: '200px' }}
-              p={4}
-              m={4}
-              onClick={() =>
-                handleAddToCart({
-                  id: v4(),
-                  name: 'めんたい',
-                  price: 300,
-                  arranges: {
-                    ソース: true,
-                    めんたいマヨ: true,
-                    チーズ: true,
-                    カツオ: true,
-                  },
-                })
-              }
-            >
-              メンタイ
-            </Button>
-            <Button
-              fontSize={{ base: '50px', sm: '24px' }}
-              h={{ base: '100px', sm: '200px' }}
-              w={{ base: '100px', sm: '200px' }}
-              p={4}
-              m={4}
-              onClick={() =>
-                handleAddToCart({
-                  id: v4(),
-                  name: 'めんたい前売り',
-                  price: 0,
-                  arranges: {
-                    ソース: true,
-                    めんたいマヨ: true,
-                    チーズ: true,
-                    カツオ: true,
-                  },
-                })
-              }
-            >
-              メンタイ前売り券
-            </Button>
-          </HStack>
-          <Button
-            fontSize={{ base: '50px', sm: '24px' }}
-            h={{ base: '100px', sm: '200px' }}
-            w={{ base: '100px', sm: '400px' }}
-            p={4}
-            m={2}
-            mb={4}
-            onClick={() => {
-              handleAddToCart({
-                id: v4(),
-                name: 'ソース（セット）前売り',
-                price: 0,
-                arranges: {
-                  ソース: true,
-                  マヨ: true,
-                  アオサ: true,
-                  カツオ: true,
-                },
-              });
-              handleAddToCart({
-                id: v4(),
-                name: 'めんたい（セット）前売り',
-                price: 0,
-                arranges: {
-                  ソース: true,
-                  めんたいマヨ: true,
-                  チーズ: true,
-                  カツオ: true,
-                },
-              });
-            }}
-          >
-            セット
-          </Button>
-        </VStack>
+        <OrderButton handleAddToCart={handleAddToCart} />
         <Card w={'60vw'} h={'96vh'} p={4} m={2}>
           <h1>注文内容</h1>
           <Stack bgColor={'gray.50'} h={'88vh'} overflow={'scroll'}>
@@ -396,6 +268,144 @@ const SetCard = ({
         </Box>
       ) : null}
     </>
+  );
+};
+
+type orderButtonProps = {
+  handleAddToCart: ({ name, price, arranges, id }: MenuInformation) => void;
+};
+
+const OrderButton: FC<orderButtonProps> = ({ handleAddToCart }) => {
+  return (
+    <VStack>
+      <OrderHistoryDrawer />
+      <HStack>
+        <Button
+          fontSize={{ base: '50px', sm: '24px' }}
+          h={{ base: '100px', sm: '200px' }}
+          w={{ base: '100px', sm: '200px' }}
+          p={4}
+          m={4}
+          onClick={() =>
+            handleAddToCart({
+              id: v4(),
+              name: 'ソース',
+              price: 250,
+              arranges: {
+                ソース: true,
+                マヨ: true,
+                アオサ: true,
+                カツオ: true,
+              },
+            })
+          }
+        >
+          ソース
+        </Button>
+        <Button
+          fontSize={{ base: '50px', sm: '24px' }}
+          h={{ base: '100px', sm: '200px' }}
+          w={{ base: '100px', sm: '200px' }}
+          p={4}
+          m={4}
+          onClick={() =>
+            handleAddToCart({
+              id: v4(),
+              name: 'ソース前売り',
+              price: 0,
+              arranges: {
+                ソース: true,
+                マヨ: true,
+                アオサ: true,
+                カツオ: true,
+              },
+            })
+          }
+        >
+          ソース前売り券
+        </Button>
+      </HStack>
+      <HStack>
+        <Button
+          fontSize={{ base: '50px', sm: '24px' }}
+          h={{ base: '100px', sm: '200px' }}
+          w={{ base: '100px', sm: '200px' }}
+          p={4}
+          m={4}
+          onClick={() =>
+            handleAddToCart({
+              id: v4(),
+              name: 'めんたい',
+              price: 300,
+              arranges: {
+                ソース: true,
+                めんたいマヨ: true,
+                チーズ: true,
+                カツオ: true,
+              },
+            })
+          }
+        >
+          メンタイ
+        </Button>
+        <Button
+          fontSize={{ base: '50px', sm: '24px' }}
+          h={{ base: '100px', sm: '200px' }}
+          w={{ base: '100px', sm: '200px' }}
+          p={4}
+          m={4}
+          onClick={() =>
+            handleAddToCart({
+              id: v4(),
+              name: 'めんたい前売り',
+              price: 0,
+              arranges: {
+                ソース: true,
+                めんたいマヨ: true,
+                チーズ: true,
+                カツオ: true,
+              },
+            })
+          }
+        >
+          メンタイ前売り券
+        </Button>
+      </HStack>
+      <Button
+        fontSize={{ base: '50px', sm: '24px' }}
+        h={{ base: '100px', sm: '200px' }}
+        w={{ base: '100px', sm: '400px' }}
+        p={4}
+        m={2}
+        mb={4}
+        onClick={() => {
+          handleAddToCart({
+            id: v4(),
+            name: 'ソース（セット）前売り',
+            price: 0,
+            arranges: {
+              ソース: true,
+              マヨ: true,
+              アオサ: true,
+              カツオ: true,
+            },
+          });
+          handleAddToCart({
+            id: v4(),
+            name: 'めんたい（セット）前売り',
+            price: 0,
+            arranges: {
+              ソース: true,
+              めんたいマヨ: true,
+              チーズ: true,
+              カツオ: true,
+            },
+          });
+        }}
+      >
+        セット
+      </Button>
+    </VStack>
   );
 };
 

--- a/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
+++ b/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
@@ -9,34 +9,29 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { Grid, GridItem } from '@chakra-ui/react';
-import { FC, useState } from 'react';
-import { v4 } from 'uuid';
-
-type Order = {
-  id: string;
-  name: string;
-  toppings: Topping;
-  price: number;
-};
-
-type Topping = {
-  ソース?: boolean;
-  マヨ?: boolean;
-  青のり?: boolean;
-  かつお節?: boolean;
-  メンタイ?: boolean;
-  チーズ?: boolean;
-};
+import { FC, useEffect } from 'react';
 import PayDrawer from './Payment';
 import OrderHistoryDrawer from './OrderHistoryDrawer';
 import { MenuInformation } from '../../../../types';
+import { v4 } from 'uuid';
+import { ArrangeState } from '../../../../state/cart/cartSlice';
 
 type ReceptionUIProps = {
   cart: MenuInformation[];
+  handleAddToCart: ({ name, price, arranges, id }: MenuInformation) => void;
+  handleDeleteFromCart: (id: string) => void;
+  handleUpdateOrderCheck: ({ id, arrange, checked }: ArrangeState) => void;
 };
 
-const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
-  const [orders, setOrders] = useState<Order[]>([]);
+const ReceptionUI: FC<ReceptionUIProps> = ({
+  cart,
+  handleAddToCart,
+  handleDeleteFromCart,
+  handleUpdateOrderCheck,
+}) => {
+  useEffect(() => {
+    console.log(cart);
+  }, [cart]);
 
   return (
     <Box maxHeight="100vh">
@@ -50,22 +45,19 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
               w={{ base: '100px', sm: '200px' }}
               p={4}
               m={4}
-              onClick={() => {
-                setOrders([
-                  ...orders,
-                  {
-                    id: v4(),
-                    name: 'ソース',
-                    toppings: {
-                      ソース: true,
-                      マヨ: true,
-                      青のり: true,
-                      かつお節: true,
-                    },
-                    price: 250,
+              onClick={() =>
+                handleAddToCart({
+                  id: v4(),
+                  name: 'ソース',
+                  price: 250,
+                  arranges: {
+                    ソース: true,
+                    マヨ: true,
+                    アオサ: true,
+                    カツオ: true,
                   },
-                ]);
-              }}
+                })
+              }
             >
               ソース
             </Button>
@@ -75,22 +67,19 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
               w={{ base: '100px', sm: '200px' }}
               p={4}
               m={4}
-              onClick={() => {
-                setOrders([
-                  ...orders,
-                  {
-                    id: v4(),
-                    name: 'ソース前売り券',
-                    toppings: {
-                      ソース: true,
-                      マヨ: true,
-                      青のり: true,
-                      かつお節: true,
-                    },
-                    price: 0,
+              onClick={() =>
+                handleAddToCart({
+                  id: v4(),
+                  name: 'ソース前売り',
+                  price: 0,
+                  arranges: {
+                    ソース: true,
+                    マヨ: true,
+                    アオサ: true,
+                    カツオ: true,
                   },
-                ]);
-              }}
+                })
+              }
             >
               ソース前売り券
             </Button>
@@ -102,22 +91,19 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
               w={{ base: '100px', sm: '200px' }}
               p={4}
               m={4}
-              onClick={() => {
-                setOrders([
-                  ...orders,
-                  {
-                    id: v4(),
-                    name: 'メンタイ',
-                    toppings: {
-                      ソース: true,
-                      メンタイ: true,
-                      チーズ: true,
-                      かつお節: true,
-                    },
-                    price: 300,
+              onClick={() =>
+                handleAddToCart({
+                  id: v4(),
+                  name: 'めんたい',
+                  price: 300,
+                  arranges: {
+                    ソース: true,
+                    めんたいマヨ: true,
+                    チーズ: true,
+                    カツオ: true,
                   },
-                ]);
-              }}
+                })
+              }
             >
               メンタイ
             </Button>
@@ -127,22 +113,19 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
               w={{ base: '100px', sm: '200px' }}
               p={4}
               m={4}
-              onClick={() => {
-                setOrders([
-                  ...orders,
-                  {
-                    id: v4(),
-                    name: 'メンタイ前売り券',
-                    toppings: {
-                      ソース: true,
-                      メンタイ: true,
-                      チーズ: true,
-                      かつお節: true,
-                    },
-                    price: 0,
+              onClick={() =>
+                handleAddToCart({
+                  id: v4(),
+                  name: 'めんたい前売り',
+                  price: 0,
+                  arranges: {
+                    ソース: true,
+                    めんたいマヨ: true,
+                    チーズ: true,
+                    カツオ: true,
                   },
-                ]);
-              }}
+                })
+              }
             >
               メンタイ前売り券
             </Button>
@@ -155,20 +138,28 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
             m={2}
             mb={4}
             onClick={() => {
-              setOrders([
-                ...orders,
-                {
-                  id: v4(),
-                  name: 'セット前売り券',
-                  toppings: {
-                    ソース: true,
-                    マヨ: true,
-                    青のり: true,
-                    かつお節: true,
-                  },
-                  price: 0,
+              handleAddToCart({
+                id: v4(),
+                name: 'ソース（セット）前売り',
+                price: 0,
+                arranges: {
+                  ソース: true,
+                  マヨ: true,
+                  アオサ: true,
+                  カツオ: true,
                 },
-              ]);
+              });
+              handleAddToCart({
+                id: v4(),
+                name: 'めんたい（セット）前売り',
+                price: 0,
+                arranges: {
+                  ソース: true,
+                  めんたいマヨ: true,
+                  チーズ: true,
+                  カツオ: true,
+                },
+              });
             }}
           >
             セット
@@ -180,7 +171,10 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
             {cart.map((order, index) =>
               order.name === 'ソース（セット）前売り' ? (
                 <HStack key={index}>
-                  <SetCard menuName={order.name} />
+                  <SetCard
+                    order={order}
+                    handleUpdateOrderCheck={handleUpdateOrderCheck}
+                  />
 
                   <Button
                     w="12vw"
@@ -188,7 +182,8 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
                     borderRadius={10}
                     m={5}
                     onClick={() => {
-                      setOrders(orders.filter((o) => o.id !== order.id));
+                      //
+                      handleDeleteFromCart(order.id);
                     }}
                   >
                     削除
@@ -203,24 +198,16 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
                     <CheckboxGroup>
                       {Object.keys(order.arranges).map((topping, i) => (
                         <Checkbox
-                          colorScheme="green"
-                          onChange={(e) =>
-                            setOrders(
-                              orders.map((o) =>
-                                o.id === order.id
-                                  ? {
-                                      ...o,
-                                      toppings: {
-                                        ...o.toppings,
-                                        [topping]: e.target.checked,
-                                      },
-                                    }
-                                  : o,
-                              ),
-                            )
-                          }
                           key={i}
-                          defaultChecked
+                          defaultChecked={true}
+                          colorScheme="green"
+                          onChange={(e) => {
+                            handleUpdateOrderCheck({
+                              id: order.id,
+                              arrange: topping,
+                              checked: e.target.checked,
+                            });
+                          }}
                         >
                           {topping}
                         </Checkbox>
@@ -228,7 +215,7 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
                     </CheckboxGroup>
                     <Button
                       onClick={() => {
-                        setOrders(orders.filter((o) => o.id !== order.id));
+                        handleDeleteFromCart(order.id);
                       }}
                     >
                       削除
@@ -243,7 +230,7 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
             <h2>
               {
                 //注文の合計金額を表示
-                orders.reduce((sum, order) => sum + order.price, 0)
+                cart.reduce((sum, order) => sum + order.price, 0)
               }
             </h2>
             <PayDrawer />
@@ -254,10 +241,16 @@ const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
   );
 };
 
-const SetCard = ({ menuName }: { menuName: string }) => {
+const SetCard = ({
+  order,
+  handleUpdateOrderCheck,
+}: {
+  order: MenuInformation;
+  handleUpdateOrderCheck: ({ id, arrange, checked }: ArrangeState) => void;
+}) => {
   return (
     <>
-      {menuName === 'セット前売り券' ? (
+      {order.name === 'ソース（セット）前売り' ? (
         <Box width={'40vw'}>
           <Grid
             templateRows="repeat(2, 1rf)"
@@ -282,16 +275,56 @@ const SetCard = ({ menuName }: { menuName: string }) => {
                 <Card w={'35vw'} minH={'8vh'}>
                   <h2>ソース（セット）前売り</h2>
                   <HStack>
-                    <Checkbox defaultChecked colorScheme="green">
+                    <Checkbox
+                      defaultChecked={true}
+                      colorScheme="green"
+                      onChange={(e) => {
+                        handleUpdateOrderCheck({
+                          id: order.id,
+                          arrange: 'ソース',
+                          checked: e.target.checked,
+                        });
+                      }}
+                    >
                       ソース
                     </Checkbox>
-                    <Checkbox defaultChecked colorScheme="green">
+                    <Checkbox
+                      defaultChecked={true}
+                      colorScheme="green"
+                      onChange={(e) => {
+                        handleUpdateOrderCheck({
+                          id: order.id,
+                          arrange: 'マヨ',
+                          checked: e.target.checked,
+                        });
+                      }}
+                    >
                       マヨ
                     </Checkbox>
-                    <Checkbox defaultChecked colorScheme="green">
+                    <Checkbox
+                      defaultChecked={true}
+                      colorScheme="green"
+                      onChange={(e) => {
+                        handleUpdateOrderCheck({
+                          id: order.id,
+                          arrange: 'アオサ',
+                          checked: e.target.checked,
+                        });
+                      }}
+                    >
                       青のり
                     </Checkbox>
-                    <Checkbox defaultChecked colorScheme="green">
+                    <Checkbox
+                      defaultChecked={true}
+                      colorScheme="green"
+                      onChange={(e) => {
+                        handleUpdateOrderCheck({
+                          id: order.id,
+                          arrange: 'カツオ',
+                          checked: e.target.checked,
+                        });
+                      }}
+                    >
                       かつお節
                     </Checkbox>
                   </HStack>
@@ -303,16 +336,56 @@ const SetCard = ({ menuName }: { menuName: string }) => {
                 <Card w={'35vw'} minH={'8vh'}>
                   <h2>めんたい（セット）前売り</h2>
                   <HStack>
-                    <Checkbox defaultChecked colorScheme="green">
+                    <Checkbox
+                      defaultChecked={true}
+                      colorScheme="green"
+                      onChange={(e) => {
+                        handleUpdateOrderCheck({
+                          id: order.id,
+                          arrange: 'ソース',
+                          checked: e.target.checked,
+                        });
+                      }}
+                    >
                       ソース
                     </Checkbox>
-                    <Checkbox defaultChecked colorScheme="green">
-                      マヨ
+                    <Checkbox
+                      defaultChecked={true}
+                      colorScheme="green"
+                      onChange={(e) => {
+                        handleUpdateOrderCheck({
+                          id: order.id,
+                          arrange: 'めんたいマヨ',
+                          checked: e.target.checked,
+                        });
+                      }}
+                    >
+                      めんたいマヨ
                     </Checkbox>
-                    <Checkbox defaultChecked colorScheme="green">
-                      青のり
+                    <Checkbox
+                      defaultChecked={true}
+                      colorScheme="green"
+                      onChange={(e) => {
+                        handleUpdateOrderCheck({
+                          id: order.id,
+                          arrange: 'チーズ',
+                          checked: e.target.checked,
+                        });
+                      }}
+                    >
+                      チーズ
                     </Checkbox>
-                    <Checkbox defaultChecked colorScheme="green">
+                    <Checkbox
+                      defaultChecked={true}
+                      colorScheme="green"
+                      onChange={(e) => {
+                        handleUpdateOrderCheck({
+                          id: order.id,
+                          arrange: 'カツオ',
+                          checked: e.target.checked,
+                        });
+                      }}
+                    >
                       かつお節
                     </Checkbox>
                   </HStack>

--- a/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
+++ b/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
@@ -21,6 +21,7 @@ type ReceptionUIProps = {
   handleAddToCart: ({ name, price, arranges, id }: MenuInformation) => void;
   handleDeleteFromCart: (id: string) => void;
   handleUpdateOrderCheck: ({ id, arrange, checked }: ArrangeState) => void;
+  handleDeleteSetMenu: (index: number) => void;
 };
 
 const ReceptionUI: FC<ReceptionUIProps> = ({
@@ -28,6 +29,7 @@ const ReceptionUI: FC<ReceptionUIProps> = ({
   handleAddToCart,
   handleDeleteFromCart,
   handleUpdateOrderCheck,
+  handleDeleteSetMenu,
 }) => {
   useEffect(() => {
     console.log(cart);
@@ -54,8 +56,7 @@ const ReceptionUI: FC<ReceptionUIProps> = ({
                     borderRadius={10}
                     m={5}
                     onClick={() => {
-                      //
-                      handleDeleteFromCart(order.id);
+                      handleDeleteSetMenu(index);
                     }}
                   >
                     削除

--- a/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
+++ b/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
@@ -9,7 +9,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { Grid, GridItem } from '@chakra-ui/react';
-import { useState } from 'react';
+import { FC, useState } from 'react';
 import { v4 } from 'uuid';
 
 type Order = {
@@ -29,8 +29,13 @@ type Topping = {
 };
 import PayDrawer from './Payment';
 import OrderHistoryDrawer from './OrderHistoryDrawer';
+import { MenuInformation } from '../../../../types';
 
-const ReceptionUI = () => {
+type ReceptionUIProps = {
+  cart: MenuInformation[];
+};
+
+const ReceptionUI: FC<ReceptionUIProps> = ({ cart }) => {
   const [orders, setOrders] = useState<Order[]>([]);
 
   return (
@@ -172,8 +177,8 @@ const ReceptionUI = () => {
         <Card w={'60vw'} h={'96vh'} p={4} m={2}>
           <h1>注文内容</h1>
           <Stack bgColor={'gray.50'} h={'88vh'} overflow={'scroll'}>
-            {orders.map((order, index) =>
-              order.name === 'セット前売り券' ? (
+            {cart.map((order, index) =>
+              order.name === 'ソース（セット）前売り' ? (
                 <HStack key={index}>
                   <SetCard menuName={order.name} />
 
@@ -189,12 +194,14 @@ const ReceptionUI = () => {
                     削除
                   </Button>
                 </HStack>
+              ) : order.name === 'めんたい（セット）前売り' ? (
+                <Box></Box>
               ) : (
                 <Card w={'54vw'} minH={'8vh'} m={2}>
                   <h2>{order.name}</h2>
                   <HStack>
                     <CheckboxGroup>
-                      {Object.keys(order.toppings).map((topping, i) => (
+                      {Object.keys(order.arranges).map((topping, i) => (
                         <Checkbox
                           colorScheme="green"
                           onChange={(e) =>

--- a/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
+++ b/frontend/src/components/features/reception/presenter/ReceptionUI.tsx
@@ -62,9 +62,9 @@ const ReceptionUI: FC<ReceptionUIProps> = ({
                   </Button>
                 </HStack>
               ) : order.name === 'めんたい（セット）前売り' ? (
-                <Box></Box>
+                <Box key={v4()}></Box>
               ) : (
-                <Card w={'54vw'} minH={'8vh'} m={2}>
+                <Card key={order.id} w={'54vw'} minH={'8vh'} m={2}>
                   <h2>{order.name}</h2>
                   <HStack>
                     <CheckboxGroup>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,8 @@ import App from './App.tsx';
 import { BrowserRouter } from 'react-router-dom';
 import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { store } from './state/store.ts';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -19,9 +21,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
       <ChakraProvider>
-        <QueryClientProvider client={queryClient}>
-          <App />
-        </QueryClientProvider>
+        <Provider store={store}>
+          <QueryClientProvider client={queryClient}>
+            <App />
+          </QueryClientProvider>
+        </Provider>
       </ChakraProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/frontend/src/state/cart/cartSlice.ts
+++ b/frontend/src/state/cart/cartSlice.ts
@@ -1,0 +1,14 @@
+import { MenuInformation } from '../../types';
+import { createSlice } from '@reduxjs/toolkit';
+
+const state = {
+  cart: [] as MenuInformation[],
+};
+
+export const cartSlice = createSlice({
+  name: 'cartSlice',
+  initialState: state,
+  reducers: {
+    //Actionを記述
+  },
+});

--- a/frontend/src/state/cart/cartSlice.ts
+++ b/frontend/src/state/cart/cartSlice.ts
@@ -1,14 +1,40 @@
 import { MenuInformation } from '../../types';
-import { createSlice } from '@reduxjs/toolkit';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 const state = {
   cart: [] as MenuInformation[],
+};
+
+export type ArrangeState = {
+  id: string;
+  arrange: string;
+  checked: boolean;
 };
 
 export const cartSlice = createSlice({
   name: 'cartSlice',
   initialState: state,
   reducers: {
-    //Actionを記述
+    addMenu: (state, action: PayloadAction<MenuInformation>): void => {
+      state.cart.push(action.payload);
+    },
+    removeMenu: (state, action: PayloadAction<string>): void => {
+      if (state.cart.length === 0) return;
+      const id = action.payload;
+      const newCart = state.cart.filter((order) => order.id !== id);
+      state.cart = newCart;
+    },
+    updateCheckBox: (state, action: PayloadAction<ArrangeState>): void => {
+      const { id, arrange, checked } = action.payload;
+      const index = state.cart.findIndex((order) => order.id === id);
+      const target = state.cart[index];
+      if ('arranges' in target) {
+        const arranges = target.arranges as { [key: string]: boolean };
+        arranges[arrange] = checked;
+      }
+      state.cart = [...state.cart];
+    },
   },
 });
+
+export const { addMenu, removeMenu, updateCheckBox } = cartSlice.actions;

--- a/frontend/src/state/cart/cartSlice.ts
+++ b/frontend/src/state/cart/cartSlice.ts
@@ -24,6 +24,10 @@ export const cartSlice = createSlice({
       const newCart = state.cart.filter((order) => order.id !== id);
       state.cart = newCart;
     },
+    removeMenuByIndex: (state, action: PayloadAction<number>): void => {
+      const index = action.payload;
+      state.cart.splice(index, 1);
+    },
     updateCheckBox: (state, action: PayloadAction<ArrangeState>): void => {
       const { id, arrange, checked } = action.payload;
       const index = state.cart.findIndex((order) => order.id === id);
@@ -37,4 +41,5 @@ export const cartSlice = createSlice({
   },
 });
 
-export const { addMenu, removeMenu, updateCheckBox } = cartSlice.actions;
+export const { addMenu, removeMenu, removeMenuByIndex, updateCheckBox } =
+  cartSlice.actions;

--- a/frontend/src/state/common/rootState.type.ts
+++ b/frontend/src/state/common/rootState.type.ts
@@ -1,0 +1,3 @@
+import { store } from '../store';
+
+export type RootState = ReturnType<typeof store.getState>;

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -1,0 +1,6 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { cartSlice } from './cart/cartSlice';
+
+export const store = configureStore({
+  reducer: cartSlice.reducer,
+});

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -54,6 +54,7 @@ type MenuForTopping = {
 
 //データベースから受け取ったメニューの型
 export type MenuInformation = {
+  id: string;
   name:
     | 'ソース前売り'
     | 'めんたい前売り'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -53,7 +53,7 @@ type MenuForTopping = {
 };
 
 //データベースから受け取ったメニューの型
-type MenuInformation = {
+export type MenuInformation = {
   name:
     | 'ソース前売り'
     | 'めんたい前売り'


### PR DESCRIPTION
## チケットへのリンク

- https://www.notion.so/POST-15c12c9700c342d48aa7326b5638fd8b?pvs=4

## やったこと

- カート情報をグローバルで管理できるようにした
- 削除時にチェックボックスがバグる問題を解消
- セットを削除した時に配列にセット商品の片側が残ってしまう現象を解決

## やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）

## 動作確認

- ローカルで確認

## 動作確認用 URL

- http://localhost:5173/reception

## スクリーンショット

- UI の変更があれば実装前後の比較スクリーンショットを添付

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
